### PR TITLE
Update compatible versions list to support Intellj IDEA version 2023.3.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       # Check out current repository
       - name: Fetch Sources
@@ -90,12 +90,12 @@ jobs:
       artifact: ${{ steps.properties.outputs.artifact }}
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       # Check out current repository
       - name: Fetch Sources
@@ -153,12 +153,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       # Check out current repository
       - name: Fetch Sources
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       # Check out current repository
       - name: Fetch Sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 # innerbuilder-generator-intellij-plugin Changelog
 
 ## [Unreleased]
+### Added
+- Updated the compatible versions list to support Intellij Idea version 2023.3.
+
+### Removed
+- Removed support for Intellij Idea versions older than 2023.1.
+
 ## [1.1.8]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.5.21"
+    id("org.jetbrains.kotlin.jvm") version "1.9.21"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.13.3"
+    id("org.jetbrains.intellij") version "1.16.1"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.2.1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,26 +3,26 @@
 
 pluginGroup = com.github.janneri.innerbuildergeneratorintellijplugin
 pluginName = innerbuilder-generator-intellij-plugin
-pluginVersion = 1.1.8
+pluginVersion = 2.0.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 222.*
-pluginUntilBuild = 232.*
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
+pluginSinceBuild = 231.*
+pluginUntilBuild = 233.*
+# Plugin Verifier integration -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#tasks-runpluginverifier
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2.1, 2023.2
+pluginVerifierIdeVersions = 2023.1, 2023.2, 2023.3
 
 platformType = IC
-platformVersion = 2020.3.4
+platformVersion = 2023.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = com.intellij.java
 
-# Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 11
+# Java language level used to compile sources and to generate the files for - Java 11 is required since 2022.2
+javaVersion = 17
 
 gradleVersion = 7.6.1
 


### PR DESCRIPTION
Also removed support for versions older than 2023.1 and updated libraries and platform version.